### PR TITLE
fix: `get_records` returns the correct object list

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,17 @@ This is a fork of the script at [pigeonburger/cloudflare-ip](https://github.com/
 | `EMAIL`     | johndoe@example.com                           | Email address associated with your CloudFlare account |
 | `AUTH_KEY`  | c2547eb745079dac9320b638f5e225cf483cc5cfdda41 | Your CloudFlare Global API Key                        |
 | `ZONE_NAME` | example.com                                   | The domain name that you want to change the record of |
+| `ZONE_ID`   | 372e67954025e0ba6aaa6d586b9e0b59              | The ID of the zone you want to change a record of     |
+
+> **Note:**
+>
+> - You only need to specify either `ZONE_ID` or `ZONE_NAME`. If you specify both, `ZONE_ID` will be used.
+>
 
 #### Optional
 
 | Variable           | Example value                    | Description                                                                                                                                | Default |
 | ------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- |
-| `ZONE_ID`          | 372e67954025e0ba6aaa6d586b9e0b59 | The ID of the zone you want to change a record of                                                                                          | -       |
 | `RECORD_ID`        | 372e67954025e0ba6aaa6d586b9e0b59 | The ID of the record you want to change. Set to `none` to update all the A record of the zone                                              | `none`  |
 | `CHECK_INTERVAL`   | 86400                            | The amount of seconds the script should wait between checks                                                                                | `86400` |
 | `SENDER_ADDRESS`   | johndoe@example.com              | The address of the email sender. Must use Gmail SMTP server                                                                                | -       |
@@ -64,11 +69,9 @@ This is a fork of the script at [pigeonburger/cloudflare-ip](https://github.com/
 
 > **Note:**
 >
-> - You only need to specify either `ZONE_ID` or `ZONE_NAME`. If you specify both, `ZONE_ID` will be used.
->
 > - `SENDER_ADDRESS` and `RECEIVER_ADDRESS` can be the same.
 
-</br>
+---
 
 ## Future implementation
 

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,8 @@ class Config(object):
         logging.debug(f"Sender password: {self.sender_password}")
         self.zone_id = utils.get_env("ZONE_ID", required=False)
         logging.debug(f"Zone ID: {self.zone_id}")
-        if (self.zone_id is None):
-            self.zone_name = utils.get_env("ZONE_NAME", required=True)
-            logging.debug(f"Zone name: {self.zone_name}")
+        self.zone_name = utils.get_env("ZONE_NAME", required=False)
+        logging.debug(f"Zone name: {self.zone_name}")
+        if (self.zone_id is None and self.zone_name is None):
+            logging.fatal("Either ZONE_ID or ZONE_NAME must be set")
+            exit(1)

--- a/src/notification.py
+++ b/src/notification.py
@@ -21,6 +21,7 @@ class Notification:
     def send_email(self, records: List[str], previous_ip: str, current_ip: str):
         content = f'The public IP of the following record(s) has changed from {previous_ip} to {current_ip}:\n\n'
         for record in records:
+            logging.debug(f"Record: {record}")
             content = content + "- " + record + "\n"
         try:
             self.smtp.send(
@@ -28,6 +29,7 @@ class Notification:
                 subject="Public IP change",
                 contents=content
             )
+            logging.info(f"Email sent.")
         except SMTPSenderRefused:
             logging.error(f"Can't send email. The sender address is invalid.")
         except SMTPAuthenticationError:
@@ -36,5 +38,3 @@ class Notification:
             logging.error(f"Can't send email. Check your receiver address.")
         except SMTPConnectError:
             logging.error(f"Can't send email. Check your internet connection.")
-        finally:
-            logging.info(f"Email sent.")

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,3 +8,9 @@ def get_env(name: str, required: bool = False, default: str = None):
         logging.fatal(f"Environment variable {name} is required")
         exit(1)
     return value
+
+def get_obj_by_attr(objs: list, attr: str, value: str):
+    for obj in objs:
+        if obj[attr] == value:
+            return obj
+    return None


### PR DESCRIPTION
# Description

`get_records` was returing a different type if a record id was specified in the env.
Now it will always return an array of objects, where the objects are the dns record objects returned by the Cloudflare API.

Additionally, it will check that the record id, if present, is actually existing.

Other minor bugfixes:
- logging
- env parsing

### Related issues

*none*

## Type of change

What types of changes does your code introduce to this project?

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run the container with both updateable and up to date records.

## Checklist

- [x] I have read the [contributing](CONTRIBUTING.md) giuidelines and the [code of conduct](CODE_OF_CONDUCT.md).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have made corresponding changes to the changelog (if needed).
- [x] I have made corresponding notices to the upgrade instructions (if needed)

## Upgrade instructions

*none*

## Additional information

*none*
